### PR TITLE
Implement profile list API and env-based fetch

### DIFF
--- a/api/src/profile/profile.controller.ts
+++ b/api/src/profile/profile.controller.ts
@@ -1,7 +1,7 @@
 // App: Client Profile Module
 // Package: api
 // File: profile.controller.ts
-// Version: 0.0.11
+// Version: 0.0.12
 // Author: Bobwares
 // Date: 2025-06-08T10:00:00Z
 // Description: HTTP controller providing profile endpoints.
@@ -16,8 +16,8 @@ export class ProfileController {
   constructor(private readonly service: ProfileService) {}
 
   @Get()
-  get(): Profile {
-    return this.service.getProfile();
+  findAll(): Promise<Profile[]> {
+    return this.service.findAll();
   }
 
   @Post()

--- a/api/src/profile/profile.service.ts
+++ b/api/src/profile/profile.service.ts
@@ -1,7 +1,7 @@
 // App: Client Profile Module
 // Package: api
 // File: profile.service.ts
-// Version: 0.0.11
+// Version: 0.0.12
 // Author: Bobwares
 // Date: 2025-06-08T10:00:00Z
 // Description: Service handling profile retrieval and updates.
@@ -18,6 +18,10 @@ export class ProfileService {
     address: '123 Street',
     photoUrl: '/photo.jpg'
   };
+
+  async findAll(): Promise<Profile[]> {
+    return [this.profile];
+  }
 
   getProfile(): Profile {
     return this.profile;

--- a/ui/.env.local
+++ b/ui/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/ui/src/components/ProfileOverview/ProfileOverview.tsx
+++ b/ui/src/components/ProfileOverview/ProfileOverview.tsx
@@ -1,7 +1,7 @@
 // App: Client Profile Module
 // Package: ui
 // File: ProfileOverview.tsx
-// Version: 0.0.11
+// Version: 0.0.12
 // Author: Bobwares
 // Date: 2025-06-08T10:00:00Z
 // Description: React component to display and edit a user's profile information with API integration.
@@ -30,12 +30,14 @@ export const ProfileOverview: FC<ProfileOverviewProps> = ({ onEdit }) => {
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  const url = `${baseUrl}/profile`;
 
   useEffect(() => {
     const controller = new AbortController();
     const load = async () => {
       try {
-        const res = await fetch('/api/profile/get', { signal: controller.signal });
+        const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error('Network response was not ok');
         const data: Profile = await res.json();
         setProfile(data);
@@ -47,7 +49,7 @@ export const ProfileOverview: FC<ProfileOverviewProps> = ({ onEdit }) => {
     };
     load();
     return () => controller.abort();
-  }, []);
+  }, [url]);
 
   const startEdit = () => {
     if (profile) {

--- a/version.md
+++ b/version.md
@@ -42,3 +42,7 @@
 ## 0.0.11 - 2025-06-08 18:57:53 UTC (work)
 - implement EditProfileForm component and integrate with ProfileOverview
 - add NestJS profile API with update endpoint and integration tests
+
+## 0.0.12 - 2025-06-09 00:15:57 UTC (work)
+- implement GET /profile endpoint returning array of Profile
+- fetch profiles in UI using base URL env variable


### PR DESCRIPTION
## Summary
- add GET /profile to return array of profiles
- use environment variable for profile fetch in ProfileOverview
- include .env.local example
- update changelog

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684627365a44832d8cade279192a3af4